### PR TITLE
Add helper to calculate clockwise arc length between two points

### DIFF
--- a/quoter/helpers.py
+++ b/quoter/helpers.py
@@ -10,3 +10,24 @@ def get_angle(vertex):
         theta = theta - (2 * np.pi)
 
     return theta
+
+
+def get_clockwise_arc_length(a, b, center=None, radius=None):
+    if center is None:
+        raise Exception('No Center', 'You need to specify a point to use as the center')
+
+    if radius is None:
+        raise Exception('No Radius', 'You need to specify the radius of your arc')
+
+    if a == b:
+        return (2 * np.pi * radius)
+    else:
+        ca = (a[0] - center[0], a[1] - center[1])
+        cb = (b[0] - center[0], b[1] - center[1])
+        theta_a = get_angle(ca)
+        theta_b = get_angle(cb)
+
+        if theta_b <= theta_a:
+            return np.abs((theta_b - theta_a) * radius)
+        else:
+            return np.abs((2 * np.pi - (theta_b - theta_a)) * radius)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -13,11 +13,19 @@ v8 = (1, 1)
 
 
 def test_get_angle():
-    assert (helpers.get_angle(v1) * 180 / np.pi) == 0.0
-    assert (helpers.get_angle(v2) * 180 / np.pi) == -45.0
-    assert (helpers.get_angle(v3) * 180 / np.pi) == -90.0
-    assert (helpers.get_angle(v4) * 180 / np.pi) == - 135.0
-    assert (helpers.get_angle(v5) * 180 / np.pi) == -180.0
-    assert (helpers.get_angle(v6) * 180 / np.pi) == -225.0
-    assert (helpers.get_angle(v7) * 180 / np.pi) == -270.0
-    assert (helpers.get_angle(v8) * 180 / np.pi) == -315.0
+    assert np.abs((helpers.get_angle(v1) * 180 / np.pi) - 0.0) < 0.00001
+    assert np.abs((helpers.get_angle(v2) * 180 / np.pi) - -45.0) < 0.00001
+    assert np.abs((helpers.get_angle(v3) * 180 / np.pi) - -90.0) < 0.00001
+    assert np.abs((helpers.get_angle(v4) * 180 / np.pi) - - 135.0) < 0.00001
+    assert np.abs((helpers.get_angle(v5) * 180 / np.pi) - -180.0) < 0.00001
+    assert np.abs((helpers.get_angle(v6) * 180 / np.pi) - -225.0) < 0.00001
+    assert np.abs((helpers.get_angle(v7) * 180 / np.pi) - -270.0) < 0.00001
+    assert np.abs((helpers.get_angle(v8) * 180 / np.pi) - -315.0) < 0.00001
+
+
+def test_get_clockwise_arc_length():
+    assert np.abs((helpers.get_clockwise_arc_length((1, 0), (0, 1), center=(1, 1), radius=1)) - (np.pi / 2)) < 0.00001
+    assert np.abs((helpers.get_clockwise_arc_length((0, 1), (1, 0), center=(1, 1), radius=1)) - (3 * np.pi / 2)) < 0.00001
+    assert np.abs((helpers.get_clockwise_arc_length((1, 2), (1, 0), center=(1, 1), radius=1)) - (np.pi)) < 0.00001
+    assert np.abs((helpers.get_clockwise_arc_length((1, 0), (1, 2), center=(1, 1), radius=1)) - (np.pi)) < 0.00001
+    assert np.abs((helpers.get_clockwise_arc_length((1, 0), (1, 0), center=(1, 1), radius=1)) - (2 * np.pi)) < 0.00001


### PR DESCRIPTION
Add a helper to calculate the clockwise arc length between two points,
where the arc is centered on a center c with radius r.
