### PR TITLE
Add a non-trivial example, combining the extruded and non-extruded case

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ python calculate.py quote -f /path/to/profile.json
 
 In order to get a quote in which the dimensions of the optimal bounding rectangle have been used type:
 ```
-python calculate.py quote -f /path/tp/profile.json --optimize-rectangle True
+python calculate.py quote -f /path/tp/profile.json --optimize-rectangle
 ```
 
 In both cases, the quote is echoed to the command line and is the dollar value estimated for cutting

--- a/calculate.py
+++ b/calculate.py
@@ -4,8 +4,7 @@ from quoter.helpers import make_quote
 
 
 @command()
-def quote(arguments,
-          filepath=('f', '', 'Path to profile representation file'),
+def quote(filepath=('f', '', 'Path to profile representation file'),
           optimize_rectangle=('', False, 'Optimize for the smallest rectangular\
             piece of stock which can contain the profile')):
     data = load_file(filepath, optimize=optimize_rectangle)

--- a/examples/MissingCorners.json
+++ b/examples/MissingCorners.json
@@ -1,0 +1,136 @@
+{
+  "Edges": {
+    "A": {
+      "Type": "LineSegment",
+      "Vertices": [
+        1,
+        2
+      ]
+    },
+    "B": {
+      "Type": "LineSegment",
+      "Vertices": [
+        5,
+        6
+      ]
+    },
+    "C": {
+      "Type": "LineSegment",
+      "Vertices": [
+        7,
+        8
+      ]
+    },
+    "D": {
+      "Type": "CircularArc",
+      "Vertices": [
+        3,
+        4
+      ],
+      "Center": {
+        "X": 4.0,
+        "Y": 1.5
+      },
+      "ClockwiseFrom": 4
+    },
+    "E": {
+      "Type": "CircularArc",
+      "Vertices": [
+        8,
+        1
+      ],
+      "Center": {
+        "X": 0.0,
+        "Y": 0.0
+      },
+      "ClockwiseFrom": 8
+    },
+    "F": {
+      "Type": "CircularArc",
+      "Vertices": [
+        2,
+        3
+      ],
+      "Center": {
+        "X": 4.0,
+        "Y": 0.0
+      },
+      "ClockwiseFrom": 2
+    },
+    "G": {
+      "Type": "CircularArc",
+      "Vertices": [
+        5,
+        4
+      ],
+      "Center": {
+        "X": 4.0,
+        "Y": 3.0
+      },
+      "ClockwiseFrom": 4
+    },
+    "H": {
+      "Type": "CircularArc",
+      "Vertices": [
+        7,
+        6
+      ],
+      "Center": {
+        "X": 0.0,
+        "Y": 3.0
+      },
+      "ClockwiseFrom": 6
+    }
+  },
+
+  "Vertices": {
+    "1": {
+      "Position": {
+        "X": 1.0,
+        "Y": 0.0
+      }
+    },
+    "2": {
+      "Position": {
+        "X": 3.0,
+        "Y": 0.0
+      }
+    },
+    "3": {
+      "Position": {
+        "X": 4.0,
+        "Y": 1.0
+      }
+    },
+    "4": {
+      "Position": {
+        "X": 4.0,
+        "Y": 2.0
+      }
+    },
+    "5": {
+      "Position": {
+        "X": 3.0,
+        "Y": 3.0
+      }
+    },
+    "6": {
+      "Position": {
+        "X": 1.0,
+        "Y": 3.0
+      }
+    },
+    "7": {
+      "Position": {
+        "X": 0.0,
+        "Y": 2.0
+      }
+    },
+    "8": {
+      "Position": {
+        "X": 0.0,
+        "Y": 1.0
+      }
+    }
+  }
+}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -91,3 +91,6 @@ def test_make_quote():
     assert '{0:.2f}'.format(helpers.make_quote(data_rect)) == '14.10'
     assert '{0:.2f}'.format(helpers.make_quote(data_extrude_circular_arc)) == '4.47'
     assert '{0:.2f}'.format(helpers.make_quote(data_circular_arc)) == '4.06'
+
+    data_missing_corners = load_file('./examples/MissingCorners.json')
+    assert '{0:.2f}'.format(helpers.make_quote(data_missing_corners)) == '15.41'


### PR DESCRIPTION
Add a non-trivial example, where curves both do and do not bulge out of the
obvious containing rectangle. Fix a mistake in the documentation. Add a
unit test based on the non-trivial example.
